### PR TITLE
(GH-14) Add test cases for TFS calls

### DIFF
--- a/src/Cake.Tfs.Tests/Cake.Tfs.Tests.csproj
+++ b/src/Cake.Tfs.Tests/Cake.Tfs.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Cake.Core" Version="0.28.0" />
     <PackageReference Include="Cake.Testing" Version="0.28.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/src/Cake.Tfs.Tests/ExceptionAssertExtensions.cs
+++ b/src/Cake.Tfs.Tests/ExceptionAssertExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace Cake.Tfs
 {
     using System;
+    using Cake.Tfs.PullRequest;
     using Xunit;
 
     /// <summary>
@@ -48,6 +49,24 @@
         public static void IsInvalidOperationException(this Exception exception)
         {
             Assert.IsType<InvalidOperationException>(exception);
+        }
+
+        /// <summary>
+        /// Checks if an exception is of type <see cref="UriFormatException"/>.
+        /// </summary>
+        /// <param name="exception">Exception to check.</param>
+        public static void IsUrlFormatException(this Exception exception)
+        {
+            Assert.IsType<UriFormatException>(exception);
+        }
+
+        /// <summary>
+        /// Checks if an exception is of type <see cref="TfsPullRequestNotFoundException"/>.
+        /// </summary>
+        /// <param name="exception">Exception to check.</param>
+        public static void IsTfsPullRequestNotFoundException(this Exception exception)
+        {
+            Assert.IsType<TfsPullRequestNotFoundException>(exception);
         }
     }
 }

--- a/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeAllSetGitClientFactory.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeAllSetGitClientFactory.cs
@@ -1,0 +1,106 @@
+﻿namespace Cake.Tfs.Tests.PullRequest.Fakes
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using Cake.Tfs.Authentication;
+    using Cake.Tfs.PullRequest;
+    using Microsoft.TeamFoundation.SourceControl.WebApi;
+    using Moq;
+
+    public class FakeAllSetGitClientFactory : FakeGitClientFactory
+    {
+        public override GitHttpClient CreateGitClient(Uri collectionUrl, ITfsCredentials credentials)
+        {
+            var mock = new Mock<GitHttpClient>(MockBehavior.Loose, collectionUrl, credentials.ToVssCredentials());
+
+            mock.Setup(arg => arg.GetPullRequestAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), null, null, null, null, null, null, default(CancellationToken)))
+                .ReturnsAsync((string project1, string repoId1, int prId, int i1, int i2, int i3, bool b1, bool b2, object o1, CancellationToken c1) => new GitPullRequest
+                {
+                    PullRequestId = prId,
+                    Repository = new GitRepository
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = repoId1
+                    },
+                    SourceRefName = "foo",
+                    TargetRefName = "master",
+                    CodeReviewId = 123,
+                    LastMergeSourceCommit = new GitCommitRef { CommitId = "4a92b977" },
+                    LastMergeTargetCommit = new GitCommitRef { CommitId = "78a3c113" }
+                });
+
+            mock.Setup(arg => arg.GetPullRequestsAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<GitPullRequestSearchCriteria>(),
+                    null,
+                    null,
+                    1,
+                    null,
+                    default(CancellationToken)))
+                .ReturnsAsync((string project2, string repoId2, GitPullRequestSearchCriteria sc, int j1, int j2, int top, object o2, CancellationToken c2)
+                    => new List<GitPullRequest>(new[]
+                    {
+                        new GitPullRequest
+                        {
+                            PullRequestId = 777,
+                            Repository = new GitRepository
+                            {
+                                Id = Guid.NewGuid(),
+                                Name = repoId2
+                            },
+                            SourceRefName = sc.SourceRefName,
+                            TargetRefName = "master",
+                            CodeReviewId = 123,
+                            LastMergeSourceCommit = new GitCommitRef { CommitId = "4a92b977" },
+                            LastMergeTargetCommit = new GitCommitRef { CommitId = "78a3c113" }
+                        }
+                    }));
+
+            mock = this.Setup(mock);
+
+            return mock.Object;
+        }
+
+        protected override Mock<GitHttpClient> Setup(Mock<GitHttpClient> m)
+        {
+            m.Setup(arg => arg.CreatePullRequestReviewerAsync(
+                    It.Is<IdentityRefWithVote>(i => Enum.IsDefined(typeof(TfsPullRequestVote), i.Vote)),
+                    It.IsAny<Guid>(),
+                    It.IsAny<int>(),
+                    It.IsAny<string>(),
+                    It.IsAny<object>(),
+                    default(CancellationToken)))
+             .ReturnsAsync((IdentityRefWithVote identity, Guid project, int prId, string reviewerId, object o, CancellationToken c)
+                    => new IdentityRefWithVote
+                    {
+                        Vote = identity.Vote,
+                    });
+
+            m.Setup(arg => arg.CreatePullRequestReviewerAsync(
+                    It.Is<IdentityRefWithVote>(i => !Enum.IsDefined(typeof(TfsPullRequestVote), i.Vote)),
+                    It.IsAny<Guid>(),
+                    It.IsAny<int>(),
+                    It.IsAny<string>(),
+                    It.IsAny<object>(),
+                    default(CancellationToken)))
+             .Throws(new Exception("Something went wrong"));
+
+            m.Setup(arg => arg.CreatePullRequestStatusAsync(
+                    It.IsAny<GitPullRequestStatus>(),
+                    It.IsAny<Guid>(),
+                    It.IsAny<int>(),
+                    It.IsAny<object>(),
+                    It.IsAny<CancellationToken>()))
+             .ReturnsAsync((GitPullRequestStatus status, Guid repoId, int prId, object o, CancellationToken c)
+                    => new GitPullRequestStatus
+                    {
+                        Context = status.Context,
+                        State = status.State
+                    });
+
+            return m;
+        }
+    }
+}

--- a/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeGitClientFactory.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeGitClientFactory.cs
@@ -1,0 +1,24 @@
+﻿namespace Cake.Tfs.Tests.PullRequest.Fakes
+{
+    using System;
+    using Cake.Tfs.Authentication;
+    using Microsoft.TeamFoundation.SourceControl.WebApi;
+    using Microsoft.VisualStudio.Services.Identity;
+    using Moq;
+
+    public abstract class FakeGitClientFactory : IGitClientFactory
+    {
+        public abstract GitHttpClient CreateGitClient(Uri collectionUrl, ITfsCredentials credentials);
+
+        public GitHttpClient CreateGitClient(Uri collectionUrl, ITfsCredentials credentials, out Identity identity)
+        {
+            identity = new Identity { ProviderDisplayName = "FakeUser", Id = Guid.NewGuid(), IsActive = true };
+            return this.CreateGitClient(collectionUrl, credentials);
+        }
+
+        protected virtual Mock<GitHttpClient> Setup(Mock<GitHttpClient> m)
+        {
+            return m;
+        }
+    }
+}

--- a/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeNullForMethodsGitClientFactory.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeNullForMethodsGitClientFactory.cs
@@ -1,0 +1,21 @@
+﻿namespace Cake.Tfs.Tests.PullRequest.Fakes
+{
+    using System;
+    using System.Threading;
+    using Microsoft.TeamFoundation.SourceControl.WebApi;
+    using Moq;
+
+    public class FakeNullForMethodsGitClientFactory : FakeAllSetGitClientFactory
+    {
+        protected override Mock<GitHttpClient> Setup(Mock<GitHttpClient> m)
+        {
+            m.Setup(arg => arg.CreatePullRequestReviewerAsync(It.IsAny<IdentityRefWithVote>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<object>(), default(CancellationToken)))
+             .ReturnsAsync(() => null);
+
+            m.Setup(arg => arg.CreatePullRequestStatusAsync(It.IsAny<GitPullRequestStatus>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(() => null);
+
+            return m;
+        }
+    }
+}

--- a/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeNullGitClientFactory.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeNullGitClientFactory.cs
@@ -1,0 +1,27 @@
+﻿namespace Cake.Tfs.Tests.PullRequest.Fakes
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using Cake.Tfs.Authentication;
+    using Microsoft.TeamFoundation.SourceControl.WebApi;
+    using Moq;
+
+    public class FakeNullGitClientFactory : FakeGitClientFactory
+    {
+        public override GitHttpClient CreateGitClient(Uri collectionUrl, ITfsCredentials credentials)
+        {
+            var mock = new Mock<GitHttpClient>(MockBehavior.Loose, collectionUrl, credentials.ToVssCredentials());
+
+            mock.Setup(arg => arg.GetPullRequestAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), null, null, null, null, null, null, default(CancellationToken)))
+                .ReturnsAsync(() => null);
+
+            mock.Setup(arg => arg.GetPullRequestsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GitPullRequestSearchCriteria>(), null, null, 1, null, default(CancellationToken)))
+                .ReturnsAsync(() => new List<GitPullRequest>());
+
+            mock = this.Setup(mock);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Cake.Tfs.Tests/PullRequest/PullRequestFixture.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/PullRequestFixture.cs
@@ -1,0 +1,41 @@
+﻿namespace Cake.Tfs.Tests.PullRequest
+{
+    using System;
+    using Cake.Testing;
+    using Cake.Tfs.Authentication;
+    using Cake.Tfs.PullRequest;
+    using Cake.Tfs.Tests.PullRequest.Fakes;
+
+    internal class PullRequestFixture
+    {
+        public const string ValidTfsUrl = "http://MyServer/tfs/MyCollection/MyTeamProject/_git/MyRepoName";
+        public const string ValidAzureDevOpsUrl = "https://my-account.visualstudio.com/DefaultCollection/MyProject/_git/MyRepoName";
+        public const string InvalidTfsUrl = "http://example.com";
+
+        public PullRequestFixture(string repoUrl, int prId)
+        {
+            this.Settings = new TfsPullRequestSettings(new Uri(repoUrl), prId, new TfsNtlmCredentials());
+
+            this.InitializeFakes();
+        }
+
+        public PullRequestFixture(string repoUrl, string sourceBranch)
+        {
+            this.Settings = new TfsPullRequestSettings(new Uri(repoUrl), sourceBranch, new TfsNtlmCredentials());
+
+            this.InitializeFakes();
+        }
+
+        public FakeLog Log { get; set; }
+
+        public TfsPullRequestSettings Settings { get; set; }
+
+        public IGitClientFactory GitClientFactory { get; set; }
+
+        private void InitializeFakes()
+        {
+            this.Log = new FakeLog();
+            this.GitClientFactory = new FakeAllSetGitClientFactory();
+        }
+    }
+}

--- a/src/Cake.Tfs.Tests/PullRequest/TfsPullRequestTests.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/TfsPullRequestTests.cs
@@ -1,10 +1,8 @@
 ﻿namespace Cake.Tfs.Tests.PullRequest
 {
-    using System;
-    using Cake.Core.Diagnostics;
-    using Cake.Testing;
-    using Cake.Tfs.Authentication;
     using Cake.Tfs.PullRequest;
+    using Cake.Tfs.Tests.PullRequest.Fakes;
+    using Microsoft.VisualStudio.Services.Common;
     using Shouldly;
     using Xunit;
 
@@ -16,11 +14,10 @@
             public void Should_Throw_If_Log_Is_Null()
             {
                 // Given
-                ICakeLog log = null;
-                var settings = new TfsPullRequestSettings(new Uri("http://example.com"), "foo", AuthenticationProvider.AuthenticationNtlm());
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, "foo") { Log = null };
 
                 // When
-                var result = Record.Exception(() => new TfsPullRequest(log, settings));
+                var result = Record.Exception(() => new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory));
 
                 // Then
                 result.IsArgumentNullException("log");
@@ -30,14 +27,388 @@
             public void Should_Throw_If_Settings_Are_Null()
             {
                 // Given
-                var log = new FakeLog();
-                TfsPullRequestSettings settings = null;
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 42) { Settings = null };
 
                 // When
-                var result = Record.Exception(() => new TfsPullRequest(log, settings));
+                var result = Record.Exception(() => new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory));
 
                 // Then
                 result.IsArgumentNullException("settings");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Git_Client_Factory_Is_Null()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 42) { GitClientFactory = null };
+
+                // When
+                var result = Record.Exception(() => new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory));
+
+                // Then
+                result.IsArgumentNullException("gitClientFactory");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Tfs_Url_Is_Invalid()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.InvalidTfsUrl, 42);
+
+                // When
+                var result = Record.Exception(() => new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory));
+
+                // Then
+                result.IsUrlFormatException();
+            }
+
+            [Fact]
+            public void Should_Return_Valid_Tfs_Pull_Request_By_Id()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 42);
+
+                // When
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // Then
+                pullRequest.ShouldNotBe(null);
+                pullRequest.HasPullRequestLoaded.ShouldBe(true);
+                pullRequest.PullRequestId.ShouldBe(42);
+                pullRequest.RepositoryName.ShouldBe("MyRepoName");
+                pullRequest.CollectionName.ShouldBe("MyCollection");
+                pullRequest.CodeReviewId.ShouldBe(123);
+                pullRequest.ProjectName.ShouldBe("MyTeamProject");
+                pullRequest.TargetRefName.ShouldBe("master");
+                pullRequest.LastSourceCommitId.ShouldBe("4a92b977");
+                pullRequest.LastTargetCommitId.ShouldBe("78a3c113");
+            }
+
+            [Fact]
+            public void Should_Return_Valid_Azure_DevOps_Pull_Request_By_Id()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidAzureDevOpsUrl, 16);
+
+                // When
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // Then
+                pullRequest.ShouldNotBe(null);
+                pullRequest.HasPullRequestLoaded.ShouldBe(true);
+                pullRequest.PullRequestId.ShouldBe(16);
+                pullRequest.RepositoryName.ShouldBe("MyRepoName");
+                pullRequest.CollectionName.ShouldBe("DefaultCollection");
+                pullRequest.CodeReviewId.ShouldBe(123);
+                pullRequest.ProjectName.ShouldBe("MyProject");
+                pullRequest.TargetRefName.ShouldBe("master");
+                pullRequest.LastSourceCommitId.ShouldBe("4a92b977");
+                pullRequest.LastTargetCommitId.ShouldBe("78a3c113");
+            }
+
+            [Fact]
+            public void Should_Return_Valid_Tfs_Pull_Request_By_Source_Branch()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, "feature");
+
+                // When
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // Then
+                pullRequest.ShouldNotBe(null);
+                pullRequest.HasPullRequestLoaded.ShouldBe(true);
+                pullRequest.PullRequestId.ShouldBe(777);
+                pullRequest.RepositoryName.ShouldBe("MyRepoName");
+                pullRequest.CollectionName.ShouldBe("MyCollection");
+                pullRequest.CodeReviewId.ShouldBe(123);
+                pullRequest.ProjectName.ShouldBe("MyTeamProject");
+                pullRequest.TargetRefName.ShouldBe("master");
+                pullRequest.LastSourceCommitId.ShouldBe("4a92b977");
+                pullRequest.LastTargetCommitId.ShouldBe("78a3c113");
+            }
+
+            [Fact]
+            public void Should_Return_Valid_Azure_DevOps_Pull_Request_By_Source_Branch()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidAzureDevOpsUrl, "feature");
+
+                // When
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // Then
+                pullRequest.ShouldNotBe(null);
+                pullRequest.HasPullRequestLoaded.ShouldBe(true);
+                pullRequest.PullRequestId.ShouldBe(777);
+                pullRequest.RepositoryName.ShouldBe("MyRepoName");
+                pullRequest.CollectionName.ShouldBe("DefaultCollection");
+                pullRequest.CodeReviewId.ShouldBe(123);
+                pullRequest.ProjectName.ShouldBe("MyProject");
+                pullRequest.TargetRefName.ShouldBe("master");
+                pullRequest.LastSourceCommitId.ShouldBe("4a92b977");
+                pullRequest.LastTargetCommitId.ShouldBe("78a3c113");
+            }
+
+            [Fact]
+            public void Should_Return_Null_Tfs_Pull_Request_By_Id()
+            {
+                // Given
+                var fixture =
+                    new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 101)
+                    {
+                        GitClientFactory = new FakeNullGitClientFactory(),
+                        Settings = { ThrowExceptionIfPullRequestCouldNotBeFound = false }
+                    };
+
+                // When
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // Then
+                pullRequest.ShouldNotBe(null);
+                pullRequest.HasPullRequestLoaded.ShouldBe(false);
+                pullRequest.RepositoryName.ShouldBe("MyRepoName");
+                pullRequest.CollectionName.ShouldBe("MyCollection");
+                pullRequest.ProjectName.ShouldBe("MyTeamProject");
+                pullRequest.PullRequestId.ShouldBe(0);
+                pullRequest.CodeReviewId.ShouldBe(0);
+                pullRequest.TargetRefName.ShouldBeEmpty();
+                pullRequest.LastSourceCommitId.ShouldBeEmpty();
+                pullRequest.LastTargetCommitId.ShouldBeEmpty();
+            }
+
+            [Fact]
+            public void Should_Return_Null_Azure_DevOps_Pull_Request_By_Id()
+            {
+                // Given
+                var fixture =
+                    new PullRequestFixture(PullRequestFixture.ValidAzureDevOpsUrl, 101)
+                    {
+                        GitClientFactory = new FakeNullGitClientFactory(),
+                        Settings = { ThrowExceptionIfPullRequestCouldNotBeFound = false }
+                    };
+
+                // When
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // Then
+                pullRequest.ShouldNotBe(null);
+                pullRequest.HasPullRequestLoaded.ShouldBe(false);
+                pullRequest.RepositoryName.ShouldBe("MyRepoName");
+                pullRequest.CollectionName.ShouldBe("DefaultCollection");
+                pullRequest.ProjectName.ShouldBe("MyProject");
+                pullRequest.PullRequestId.ShouldBe(0);
+                pullRequest.CodeReviewId.ShouldBe(0);
+                pullRequest.TargetRefName.ShouldBeEmpty();
+                pullRequest.LastSourceCommitId.ShouldBeEmpty();
+                pullRequest.LastTargetCommitId.ShouldBeEmpty();
+            }
+
+            [Fact]
+            public void Should_Return_Null_Tfs_Pull_Request_By_Branch()
+            {
+                // Given
+                var fixture =
+                    new PullRequestFixture(PullRequestFixture.ValidTfsUrl, "somebranch")
+                    {
+                        GitClientFactory = new FakeNullGitClientFactory(),
+                        Settings = { ThrowExceptionIfPullRequestCouldNotBeFound = false }
+                    };
+
+                // When
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // Then
+                pullRequest.ShouldNotBe(null);
+                pullRequest.HasPullRequestLoaded.ShouldBe(false);
+                pullRequest.RepositoryName.ShouldBe("MyRepoName");
+                pullRequest.CollectionName.ShouldBe("MyCollection");
+                pullRequest.ProjectName.ShouldBe("MyTeamProject");
+                pullRequest.PullRequestId.ShouldBe(0);
+                pullRequest.CodeReviewId.ShouldBe(0);
+                pullRequest.TargetRefName.ShouldBeEmpty();
+                pullRequest.LastSourceCommitId.ShouldBeEmpty();
+                pullRequest.LastTargetCommitId.ShouldBeEmpty();
+            }
+
+            [Fact]
+            public void Should_Return_Null_Azure_DevOps_Pull_Request_By_Branch()
+            {
+                // Given
+                var fixture =
+                    new PullRequestFixture(PullRequestFixture.ValidAzureDevOpsUrl, "somebranch")
+                    {
+                        GitClientFactory = new FakeNullGitClientFactory(),
+                        Settings = { ThrowExceptionIfPullRequestCouldNotBeFound = false }
+                    };
+
+                // When
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // Then
+                pullRequest.ShouldNotBe(null);
+                pullRequest.HasPullRequestLoaded.ShouldBe(false);
+                pullRequest.RepositoryName.ShouldBe("MyRepoName");
+                pullRequest.CollectionName.ShouldBe("DefaultCollection");
+                pullRequest.ProjectName.ShouldBe("MyProject");
+                pullRequest.PullRequestId.ShouldBe(0);
+                pullRequest.CodeReviewId.ShouldBe(0);
+                pullRequest.TargetRefName.ShouldBeEmpty();
+                pullRequest.LastSourceCommitId.ShouldBeEmpty();
+                pullRequest.LastTargetCommitId.ShouldBeEmpty();
+            }
+
+            [Fact]
+            public void Should_Throw_If_Strict_Is_On_And_Pull_Request_Is_Null_By_Id()
+            {
+                // Given
+                var fixture =
+                    new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 1)
+                    {
+                        GitClientFactory = new FakeNullGitClientFactory()
+                    };
+
+                // When
+                var result = Record.Exception(() => new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory));
+
+                // Then
+                result.IsTfsPullRequestNotFoundException();
+            }
+
+            [Fact]
+            public void Should_Throw_If_Strict_Is_On_And_Pull_Request_Is_Null_By_Branch()
+            {
+                // Given
+                var fixture =
+                    new PullRequestFixture(PullRequestFixture.ValidTfsUrl, "feature")
+                    {
+                        GitClientFactory = new FakeNullGitClientFactory()
+                    };
+
+                // When
+                var result = Record.Exception(() => new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory));
+
+                // Then
+                result.IsTfsPullRequestNotFoundException();
+            }
+        }
+
+        public sealed class Vote
+        {
+            [Fact]
+            public void Should_Set_Approved_Vote_On_Tfs_Pull_Request()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 23);
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                pullRequest.Vote(TfsPullRequestVote.Approved);
+
+                // Then
+                // ?? Nothing to validate here since the method returns void
+            }
+
+            [Fact]
+            public void Should_Throw_If_Vote_Value_Is_Invalid_On_Tfs_Pull_Request()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 23);
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                var result = Record.Exception(() => pullRequest.Vote((TfsPullRequestVote)3));
+
+                // Then
+                result.ShouldNotBe(null);
+                result.IsExpected("Vote");
+                result.Message.ShouldBe("Something went wrong");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Null_Is_Returned_On_Tfs_Pull_Request()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 23)
+                {
+                    GitClientFactory = new FakeNullForMethodsGitClientFactory()
+                };
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                var result = Record.Exception(() => pullRequest.Vote(TfsPullRequestVote.WaitingForAuthor));
+
+                // Then
+                result.ShouldNotBe(null);
+                result.IsExpected("Vote");
+            }
+        }
+
+        public sealed class SetStatus
+        {
+            [Fact]
+            public void Should_Throw_If_Tfs_Pull_Request_Status_Is_Null()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 16);
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                var result = Record.Exception(() => pullRequest.SetStatus(null));
+
+                // Then
+                result.IsArgumentNullException("status");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Tfs_Pull_Request_State_Is_Invalid()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 16);
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+                var status = new TfsPullRequestStatus("whatever") { State = (TfsPullRequestStatusState)123 };
+
+                // When
+                var result = Record.Exception(() => pullRequest.SetStatus(status));
+
+                // Then
+                result.ShouldNotBe(null);
+                result.IsExpected("SetStatus");
+                result.Message.ShouldBe("Unknown value");
+            }
+
+            [Fact]
+            public void Should_Set_Valid_Status_On_Tfs_Pull_Request()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 16);
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+                var status = new TfsPullRequestStatus("Hello") { State = TfsPullRequestStatusState.Succeeded };
+
+                // When
+                pullRequest.SetStatus(status);
+
+                // Then
+                // ?? Nothing to validate here since the method returns void
+            }
+
+            [Fact]
+            public void Should_Throw_If_Null_Is_Returned_On_Tfs_Pull_Request()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 16)
+                {
+                    GitClientFactory = new FakeNullForMethodsGitClientFactory()
+                };
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+                var status = new TfsPullRequestStatus("One") { State = TfsPullRequestStatusState.Failed };
+
+                // When
+                var result = Record.Exception(() => pullRequest.SetStatus(status));
+
+                // Then
+                result.ShouldNotBe(null);
+                result.IsExpected("SetStatus");
             }
         }
     }

--- a/src/Cake.Tfs/PullRequest/GitClient/GitClientFactory.cs
+++ b/src/Cake.Tfs/PullRequest/GitClient/GitClientFactory.cs
@@ -1,0 +1,46 @@
+﻿namespace Cake.Tfs
+{
+    using System;
+    using Cake.Tfs.Authentication;
+    using Microsoft.TeamFoundation.SourceControl.WebApi;
+    using Microsoft.VisualStudio.Services.Identity;
+    using Microsoft.VisualStudio.Services.WebApi;
+
+    /// <inheritdoc />
+    internal class GitClientFactory : IGitClientFactory
+    {
+        /// <summary>
+        /// Creates a client object for communicating with Team Foundation Server or Azure DevOps.
+        /// </summary>
+        /// <param name="collectionUrl">The URL of the TFS/Azure DevOps team project collection.</param>
+        /// <param name="credentials">The credentials to connect to TFS/Azure DevOps.</param>
+        /// <param name="authorizedIdentity">Returns identity which is authorized.</param>
+        /// <returns>Client object for communicating with Team Foundation Server or Azure DevOps</returns>
+        public GitHttpClient CreateGitClient(Uri collectionUrl, ITfsCredentials credentials, out Identity authorizedIdentity)
+        {
+            var connection =
+                new VssConnection(collectionUrl, credentials.ToVssCredentials());
+
+            authorizedIdentity = connection.AuthorizedIdentity;
+
+            var gitClient = connection.GetClient<GitHttpClient>();
+            if (gitClient == null)
+            {
+                throw new TfsException("Could not retrieve the GitHttpClient object");
+            }
+
+            return gitClient;
+        }
+
+        /// <summary>
+        /// Creates a client object for communicating with Team Foundation Server or Azure DevOps.
+        /// </summary>
+        /// <param name="collectionUrl">The URL of the TFS/Azure DevOps team project collection.</param>
+        /// <param name="credentials">The credentials to connect to TFS/Azure DevOps.</param>
+        /// <returns>Client object for communicating with Team Foundation Server or Azure DevOps</returns>
+        public GitHttpClient CreateGitClient(Uri collectionUrl, ITfsCredentials credentials)
+        {
+            return this.CreateGitClient(collectionUrl, credentials, out _);
+        }
+    }
+}

--- a/src/Cake.Tfs/PullRequest/GitClient/IGitClientFactory.cs
+++ b/src/Cake.Tfs/PullRequest/GitClient/IGitClientFactory.cs
@@ -1,0 +1,30 @@
+﻿namespace Cake.Tfs
+{
+    using System;
+    using Cake.Tfs.Authentication;
+    using Microsoft.TeamFoundation.SourceControl.WebApi;
+    using Microsoft.VisualStudio.Services.Identity;
+
+    /// <summary>
+    /// The interface for a Git client factory
+    /// </summary>
+    public interface IGitClientFactory
+    {
+        /// <summary>
+        /// Creates the instance of the <see cref="GitHttpClient"/> class.
+        /// </summary>
+        /// <param name="collectionUrl">The URL of the TFS/Azure DevOps team project collection.</param>
+        /// <param name="credentials">The credentials to connect to TFS/Azure DevOps.</param>
+        /// <returns>The instance of <see cref="GitHttpClient"/> class.</returns>
+        GitHttpClient CreateGitClient(Uri collectionUrl, ITfsCredentials credentials);
+
+        /// <summary>
+        /// Creates the instance of the <see cref="GitHttpClient"/> class.
+        /// </summary>
+        /// <param name="collectionUrl">The URL of the TFS/Azure DevOps team project collection.</param>
+        /// <param name="credentials">The credentials to connect to TFS/Azure DevOps.</param>
+        /// <param name="identity">Returns identity which is authorized.</param>
+        /// <returns>The instance of <see cref="GitHttpClient"/> class.</returns>
+        GitHttpClient CreateGitClient(Uri collectionUrl, ITfsCredentials credentials, out Identity identity);
+    }
+}

--- a/src/Cake.Tfs/TfsAliases.PullRequest.cs
+++ b/src/Cake.Tfs/TfsAliases.PullRequest.cs
@@ -46,7 +46,7 @@
             context.NotNull(nameof(context));
             settings.NotNull(nameof(settings));
 
-            var pullRequest = new TfsPullRequest(context.Log, settings);
+            var pullRequest = new TfsPullRequest(context.Log, settings, new GitClientFactory());
 
             if (pullRequest.HasPullRequestLoaded)
             {
@@ -125,7 +125,7 @@
             context.NotNull(nameof(context));
             settings.NotNull(nameof(settings));
 
-            new TfsPullRequest(context.Log, settings).Vote(vote);
+            new TfsPullRequest(context.Log, settings, new GitClientFactory()).Vote(vote);
         }
 
         /// <summary>
@@ -172,7 +172,7 @@
             settings.NotNull(nameof(settings));
             status.NotNull(nameof(status));
 
-            new TfsPullRequest(context.Log, settings).SetStatus(status);
+            new TfsPullRequest(context.Log, settings, new GitClientFactory()).SetStatus(status);
         }
     }
 }


### PR DESCRIPTION
@pascalberger This is the very first draft to serve as a proof of concept for the idea. It contains just one ugly ctor test using the mocked `GitHttpClient`. I had to make the interface of the factory `public` since it complained when being used from the `public` ctor of the `TfsPullRequest`. 

In general, does it resemble what you have in mind? I would appreciate your review. 

Fixes #14.