### PR TITLE
(GH-36) Return source branch for pull request

### DIFF
--- a/src/Cake.Tfs.Tests/PullRequest/TfsPullRequestTests.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/TfsPullRequestTests.cs
@@ -79,6 +79,7 @@
                 pullRequest.CollectionName.ShouldBe("MyCollection");
                 pullRequest.CodeReviewId.ShouldBe(123);
                 pullRequest.ProjectName.ShouldBe("MyTeamProject");
+                pullRequest.SourceRefName.ShouldBe("foo");
                 pullRequest.TargetRefName.ShouldBe("master");
                 pullRequest.LastSourceCommitId.ShouldBe("4a92b977");
                 pullRequest.LastTargetCommitId.ShouldBe("78a3c113");
@@ -101,6 +102,7 @@
                 pullRequest.CollectionName.ShouldBe("DefaultCollection");
                 pullRequest.CodeReviewId.ShouldBe(123);
                 pullRequest.ProjectName.ShouldBe("MyProject");
+                pullRequest.SourceRefName.ShouldBe("foo");
                 pullRequest.TargetRefName.ShouldBe("master");
                 pullRequest.LastSourceCommitId.ShouldBe("4a92b977");
                 pullRequest.LastTargetCommitId.ShouldBe("78a3c113");
@@ -123,6 +125,7 @@
                 pullRequest.CollectionName.ShouldBe("MyCollection");
                 pullRequest.CodeReviewId.ShouldBe(123);
                 pullRequest.ProjectName.ShouldBe("MyTeamProject");
+                pullRequest.SourceRefName.ShouldBe("feature");
                 pullRequest.TargetRefName.ShouldBe("master");
                 pullRequest.LastSourceCommitId.ShouldBe("4a92b977");
                 pullRequest.LastTargetCommitId.ShouldBe("78a3c113");
@@ -145,6 +148,7 @@
                 pullRequest.CollectionName.ShouldBe("DefaultCollection");
                 pullRequest.CodeReviewId.ShouldBe(123);
                 pullRequest.ProjectName.ShouldBe("MyProject");
+                pullRequest.SourceRefName.ShouldBe("feature");
                 pullRequest.TargetRefName.ShouldBe("master");
                 pullRequest.LastSourceCommitId.ShouldBe("4a92b977");
                 pullRequest.LastTargetCommitId.ShouldBe("78a3c113");
@@ -172,6 +176,7 @@
                 pullRequest.ProjectName.ShouldBe("MyTeamProject");
                 pullRequest.PullRequestId.ShouldBe(0);
                 pullRequest.CodeReviewId.ShouldBe(0);
+                pullRequest.SourceRefName.ShouldBeEmpty();
                 pullRequest.TargetRefName.ShouldBeEmpty();
                 pullRequest.LastSourceCommitId.ShouldBeEmpty();
                 pullRequest.LastTargetCommitId.ShouldBeEmpty();
@@ -199,6 +204,7 @@
                 pullRequest.ProjectName.ShouldBe("MyProject");
                 pullRequest.PullRequestId.ShouldBe(0);
                 pullRequest.CodeReviewId.ShouldBe(0);
+                pullRequest.SourceRefName.ShouldBeEmpty();
                 pullRequest.TargetRefName.ShouldBeEmpty();
                 pullRequest.LastSourceCommitId.ShouldBeEmpty();
                 pullRequest.LastTargetCommitId.ShouldBeEmpty();
@@ -226,6 +232,7 @@
                 pullRequest.ProjectName.ShouldBe("MyTeamProject");
                 pullRequest.PullRequestId.ShouldBe(0);
                 pullRequest.CodeReviewId.ShouldBe(0);
+                pullRequest.SourceRefName.ShouldBeEmpty();
                 pullRequest.TargetRefName.ShouldBeEmpty();
                 pullRequest.LastSourceCommitId.ShouldBeEmpty();
                 pullRequest.LastTargetCommitId.ShouldBeEmpty();
@@ -253,6 +260,7 @@
                 pullRequest.ProjectName.ShouldBe("MyProject");
                 pullRequest.PullRequestId.ShouldBe(0);
                 pullRequest.CodeReviewId.ShouldBe(0);
+                pullRequest.SourceRefName.ShouldBeEmpty();
                 pullRequest.TargetRefName.ShouldBeEmpty();
                 pullRequest.LastSourceCommitId.ShouldBeEmpty();
                 pullRequest.LastTargetCommitId.ShouldBeEmpty();

--- a/src/Cake.Tfs/PullRequest/TfsPullRequest.cs
+++ b/src/Cake.Tfs/PullRequest/TfsPullRequest.cs
@@ -199,6 +199,26 @@
         }
 
         /// <summary>
+        /// Gets the name of the source branch
+        /// </summary>
+        /// Returns <see cref="string.Empty"/> if no pull request could be found and
+        /// <see cref="TfsPullRequestSettings.ThrowExceptionIfPullRequestCouldNotBeFound"/> is set to <c>false</c>.
+        /// <exception cref="TfsPullRequestNotFoundException">If pull request could not be found and
+        /// <see cref="TfsPullRequestSettings.ThrowExceptionIfPullRequestCouldNotBeFound"/> is set to <c>true</c>.</exception>
+        public string SourceRefName
+        {
+            get
+            {
+                if (!this.ValidatePullRequest())
+                {
+                    return string.Empty;
+                }
+
+                return this.pullRequest.SourceRefName;
+            }
+        }
+
+        /// <summary>
         /// Gets the name of the target branch.
         /// Returns <see cref="string.Empty"/> if no pull request could be found and
         /// <see cref="TfsPullRequestSettings.ThrowExceptionIfPullRequestCouldNotBeFound"/> is set to <c>false</c>.


### PR DESCRIPTION
This brings the `SourceRefName` property and appropriate parts of the unit tests in.

Fixes #36