### PR TITLE
Don't set build number for PR builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,5 +11,9 @@ pr:
 - develop
 
 steps:
-- powershell: ./build.ps1
+- powershell: |
+   $ENV:CAKE_SKIP_GITVERSION=([string]::IsNullOrEmpty($ENV:SYSTEM_PULLREQUEST_PULLREQUESTID) -eq $False).ToString()
+   
+   .\build.ps1
+   exit $LASTEXITCODE 
   displayName: 'Cake Build'


### PR DESCRIPTION
Don't set build number for PR builds as this is not possible on Azure DevOps