### PR TITLE
(GH-5) Move GetModifiedFiles method from Cake.Issues.PullRequests.Tfs repo

### DIFF
--- a/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeAllSetGitClientFactory.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeAllSetGitClientFactory.cs
@@ -100,6 +100,43 @@
                         State = status.State
                     });
 
+            // Setup CommitDiffs object
+            var gitChanges = new List<GitChange>
+            {
+                new GitChange
+                {
+                    ChangeId = 1,
+                    ChangeType = VersionControlChangeType.Edit,
+                    Item = new GitItem("/src/project/myclass.cs", "ID1", GitObjectType.Commit, "6b13ff8", 0)
+                },
+                null,
+                new GitChange
+                {
+                    ChangeId = 2,
+                    ChangeType = VersionControlChangeType.Edit,
+                    Item = new GitItem("/tools/folder", "ID2", GitObjectType.Tree, "6b13ff8", 0)
+                }
+            };
+
+            var gitCommitDiffs = new GitCommitDiffs
+            {
+                ChangeCounts = new Dictionary<VersionControlChangeType, int> { { VersionControlChangeType.Edit, 2 } },
+                Changes = gitChanges
+            };
+
+            m.Setup(arg => arg.GetCommitDiffsAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<Guid>(),
+                    true,
+                    null,
+                    null,
+                    It.IsAny<GitBaseVersionDescriptor>(),
+                    It.IsAny<GitTargetVersionDescriptor>(),
+                    null,
+                    CancellationToken.None))
+             .ReturnsAsync((string prj, Guid rId, bool? b, int? t, int? s, GitBaseVersionDescriptor bvd, GitTargetVersionDescriptor tvd, object o1, CancellationToken c1)
+                    => gitCommitDiffs);
+
             return m;
         }
     }

--- a/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeNullForMethodsGitClientFactory.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeNullForMethodsGitClientFactory.cs
@@ -1,6 +1,7 @@
 ﻿namespace Cake.Tfs.Tests.PullRequest.Fakes
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using Microsoft.TeamFoundation.SourceControl.WebApi;
     using Moq;
@@ -14,6 +15,10 @@
 
             m.Setup(arg => arg.CreatePullRequestStatusAsync(It.IsAny<GitPullRequestStatus>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<object>(), It.IsAny<CancellationToken>()))
              .ReturnsAsync(() => null);
+
+            m.Setup(arg => arg.GetCommitDiffsAsync(It.IsAny<string>(), It.IsAny<Guid>(), true, null, null, It.IsAny<GitBaseVersionDescriptor>(), It.IsAny<GitTargetVersionDescriptor>(), null, CancellationToken.None))
+             .ReturnsAsync(()
+                    => new GitCommitDiffs { ChangeCounts = new Dictionary<VersionControlChangeType, int>(), Changes = new List<GitChange>() });
 
             return m;
         }

--- a/src/Cake.Tfs/Cake.Tfs.csproj
+++ b/src/Cake.Tfs/Cake.Tfs.csproj
@@ -25,8 +25,8 @@
     <PackageReference Include="Cake.Core" Version="0.28.0" />
     <PackageReference Include="Costura.Fody" Version="3.1.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="15.112.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="15.112.1" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="15.131.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="15.131.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
     <PackageReference Include="TfsUrlParser" Version="1.2.0" />
   </ItemGroup>


### PR DESCRIPTION
This is the start of moving *low-hanging fruits* from Cake.Issues.PullRequests.Tfs in scope of [this one](https://github.com/cake-contrib/Cake.Issues.PullRequests.Tfs/issues/22). I would appreciate your review. 

I had to do a couple of extra things not directly related to the topic:

- Bump the version of TFS client libraries to avoid `Inheritance security rules violated by type` error, which was apparently a [compatibility issue in `System.Net.Http` version 4.1.0](https://stackoverflow.com/questions/45486980/visual-studio-team-services-api-example-throwing-system-net-http-error). Referncing the `System.Net.Http` directly, as suggested in that SO thread, is obviously not an option.

- Introduce a two-param ctor overload for `TfsPullRequest`, as long as it is used in the Cake.Issues.Requests.Tfs repo.

I'm going to accumulate all things that can easily be moved in this PR, so that those could be merged in one go. Please, let me know if you'd prefer a separate PR for each.

Fixes #5 