### PR TITLE
Add methods to get and update comment thread and some wrapper classes

### DIFF
--- a/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeAllSetGitClientFactory.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeAllSetGitClientFactory.cs
@@ -183,6 +183,15 @@
              .ReturnsAsync((Guid rId, int prId, int? it, int? baseIt, object o, CancellationToken c)
                     => commentThreads);
 
+            m.Setup(arg => arg.CreateThreadAsync(
+                It.IsAny<GitPullRequestCommentThread>(),
+                It.IsAny<Guid>(),
+                It.IsAny<int>(),
+                null,
+                CancellationToken.None))
+             .ReturnsAsync((GitPullRequestCommentThread prct, Guid g, int i, object o, CancellationToken c)
+                    => prct);
+
             return m;
         }
     }

--- a/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeAllSetGitClientFactory.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeAllSetGitClientFactory.cs
@@ -147,6 +147,42 @@
              .ReturnsAsync((GitPullRequestCommentThread prct, Guid g, int prId, int thId, object o, CancellationToken c)
                     => new GitPullRequestCommentThread { Id = thId, Status = prct.Status });
 
+            // Setup GitPullRequestCommentThread collection
+            var commentThreads = new List<GitPullRequestCommentThread>
+            {
+                new GitPullRequestCommentThread
+                {
+                    Id = 11,
+                    ThreadContext = new CommentThreadContext()
+                    {
+                        FilePath = "/some/path/to/file.cs"
+                    },
+                    Comments = new List<Comment>
+                    {
+                        new Comment { Content = "Hello", IsDeleted = false, CommentType = CommentType.CodeChange },
+                        new Comment { Content = "Goodbye", IsDeleted = true, CommentType = CommentType.Text }
+                    },
+                    Status = CommentThreadStatus.Active
+                },
+                new GitPullRequestCommentThread
+                {
+                    Id = 22,
+                    ThreadContext = null,
+                    Comments = new List<Comment>(),
+                    Status = CommentThreadStatus.Fixed
+                }
+            };
+
+            m.Setup(arg => arg.GetThreadsAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<int>(),
+                null,
+                null,
+                null,
+                CancellationToken.None))
+             .ReturnsAsync((Guid rId, int prId, int? it, int? baseIt, object o, CancellationToken c)
+                    => commentThreads);
+
             return m;
         }
     }

--- a/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeAllSetGitClientFactory.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeAllSetGitClientFactory.cs
@@ -134,8 +134,18 @@
                     It.IsAny<GitTargetVersionDescriptor>(),
                     null,
                     CancellationToken.None))
-             .ReturnsAsync((string prj, Guid rId, bool? b, int? t, int? s, GitBaseVersionDescriptor bvd, GitTargetVersionDescriptor tvd, object o1, CancellationToken c1)
+             .ReturnsAsync((string prj, Guid rId, bool? b, int? t, int? s, GitBaseVersionDescriptor bvd, GitTargetVersionDescriptor tvd, object o, CancellationToken c)
                     => gitCommitDiffs);
+
+            m.Setup(arg => arg.UpdateThreadAsync(
+                It.IsAny<GitPullRequestCommentThread>(),
+                It.IsAny<Guid>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                null,
+                CancellationToken.None))
+             .ReturnsAsync((GitPullRequestCommentThread prct, Guid g, int prId, int thId, object o, CancellationToken c)
+                    => new GitPullRequestCommentThread { Id = thId, Status = prct.Status });
 
             return m;
         }

--- a/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeNullForMethodsGitClientFactory.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeNullForMethodsGitClientFactory.cs
@@ -20,6 +20,9 @@
              .ReturnsAsync(()
                     => new GitCommitDiffs { ChangeCounts = new Dictionary<VersionControlChangeType, int>(), Changes = new List<GitChange>() });
 
+            m.Setup(arg => arg.UpdateThreadAsync(It.IsAny<GitPullRequestCommentThread>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), null, CancellationToken.None))
+             .ReturnsAsync(() => null);
+
             return m;
         }
     }

--- a/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeNullForMethodsGitClientFactory.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeNullForMethodsGitClientFactory.cs
@@ -23,6 +23,9 @@
             m.Setup(arg => arg.UpdateThreadAsync(It.IsAny<GitPullRequestCommentThread>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), null, CancellationToken.None))
              .ReturnsAsync(() => null);
 
+            m.Setup(arg => arg.GetThreadsAsync(It.IsAny<Guid>(), It.IsAny<int>(), null, null, null, CancellationToken.None))
+             .ReturnsAsync(() => new List<GitPullRequestCommentThread>());
+
             return m;
         }
     }

--- a/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeNullForMethodsGitClientFactory.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeNullForMethodsGitClientFactory.cs
@@ -26,6 +26,9 @@
             m.Setup(arg => arg.GetThreadsAsync(It.IsAny<Guid>(), It.IsAny<int>(), null, null, null, CancellationToken.None))
              .ReturnsAsync(() => new List<GitPullRequestCommentThread>());
 
+            m.Setup(arg => arg.CreateThreadAsync(It.IsAny<GitPullRequestCommentThread>(), It.IsAny<Guid>(), It.IsAny<int>(), null, CancellationToken.None))
+                .ReturnsAsync(() => null);
+
             return m;
         }
     }

--- a/src/Cake.Tfs.Tests/PullRequest/TfsCommentTests.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/TfsCommentTests.cs
@@ -1,0 +1,92 @@
+﻿namespace Cake.Tfs.Tests.PullRequest
+{
+    using Cake.Tfs.PullRequest.CommentThread;
+    using Microsoft.TeamFoundation.SourceControl.WebApi;
+    using Shouldly;
+    using Xunit;
+
+    public sealed class TfsCommentTests
+    {
+        [Fact]
+        public void Should_Throw_If_Comment_Is_Null()
+        {
+            // Given, When
+            var result = Record.Exception(() => new TfsComment(null));
+
+            // Then
+            result.IsArgumentNullException("comment");
+        }
+
+        [Fact]
+        public void Should_Throw_If_Comment_Content_Is_Null()
+        {
+            // Given, When
+            var result = Record.Exception(() => new TfsComment(null, false));
+
+            // Then
+            result.IsArgumentNullException("content");
+        }
+
+        [Fact]
+        public void Should_Throw_If_Comment_Content_Is_Empty()
+        {
+            // Given, When
+            var result = Record.Exception(() => new TfsComment(string.Empty, false));
+
+            // Then
+            result.IsArgumentOutOfRangeException("content");
+        }
+
+        [Fact]
+        public void Should_Return_Empty_Comment()
+        {
+            // Given, When
+            var comment = new TfsComment();
+
+            // Then
+            comment.ShouldNotBeNull();
+            comment.Content.ShouldBe(default(string));
+            comment.IsDeleted.ShouldBe(default(bool));
+            comment.CommentType.ShouldBe(default(TfsCommentType));
+        }
+
+        [Fact]
+        public void Should_Return_Valid_Comment_With_Default_Comment_Type()
+        {
+            // Given, When
+            var comment = new TfsComment("Hello", false);
+
+            // Then
+            comment.ShouldNotBeNull();
+            comment.Content.ShouldBe("Hello");
+            comment.IsDeleted.ShouldBeFalse();
+            comment.CommentType.ShouldBe(default(TfsCommentType));
+        }
+
+        [Fact]
+        public void Should_Return_Valid_Comment_Via_Ctor()
+        {
+            // Given, When
+            var comment = new TfsComment("What's up?", true, CommentType.Text);
+
+            // Then
+            comment.ShouldNotBeNull();
+            comment.Content.ShouldBe("What's up?");
+            comment.IsDeleted.ShouldBeTrue();
+            comment.CommentType.ShouldBe(TfsCommentType.Text);
+        }
+
+        [Fact]
+        public void Should_Return_Valid_Comment_Via_Initializers()
+        {
+            // Given, When
+            var comment = new TfsComment { Content = "All good", IsDeleted = false, CommentType = TfsCommentType.CodeChange };
+
+            // Then
+            comment.ShouldNotBeNull();
+            comment.Content.ShouldBe("All good");
+            comment.IsDeleted.ShouldBeFalse();
+            comment.CommentType.ShouldBe(TfsCommentType.CodeChange);
+        }
+    }
+}

--- a/src/Cake.Tfs.Tests/PullRequest/TfsPullRequestCommentThreadTests.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/TfsPullRequestCommentThreadTests.cs
@@ -1,0 +1,368 @@
+﻿namespace Cake.Tfs.Tests.PullRequest
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Cake.Tfs.PullRequest.CommentThread;
+    using Microsoft.TeamFoundation.SourceControl.WebApi;
+    using Microsoft.VisualStudio.Services.WebApi;
+    using Shouldly;
+    using Xunit;
+
+    public sealed class TfsPullRequestCommentThreadTests
+    {
+        public sealed class Ctor
+        {
+            [Fact]
+            public void Should_Throw_If_Input_Thread_IsNull()
+            {
+                // Given, When
+                var result = Record.Exception(() => new TfsPullRequestCommentThread(null));
+
+                // Then
+                result.IsArgumentNullException("thread");
+            }
+
+            [Fact]
+            public void Should_Return_Empty_Comment_Thread()
+            {
+                // Given, When
+                var thread = new TfsPullRequestCommentThread();
+                var getCommentsResult = Record.Exception(() => thread.Comments);
+
+                // Then
+                thread.ShouldNotBeNull();
+                thread.InnerThread.ShouldBeOfType(typeof(GitPullRequestCommentThread));
+                thread.Id.ShouldBe(default(int));
+                thread.FilePath.ShouldBeNull();
+                thread.Status.ShouldBe(default(TfsCommentThreadStatus));
+                thread.Properties.ShouldBeNull();
+
+                getCommentsResult.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Return_Valid_Comment_Thread()
+            {
+                // Given
+                var gitCommentThread = new GitPullRequestCommentThread
+                {
+                    Id = 42,
+                    Status = CommentThreadStatus.Pending,
+                    ThreadContext = new CommentThreadContext { FilePath = "/src/myclass.cs" },
+                    Comments = new List<Comment> { new Comment { Content = "Hello", CommentType = CommentType.Text, IsDeleted = false } },
+                    Properties = new PropertiesCollection()
+                };
+
+                // When
+                var tfsCommentThread = new TfsPullRequestCommentThread(gitCommentThread);
+
+                // Then
+                tfsCommentThread.ShouldNotBeNull();
+                tfsCommentThread.Id.ShouldBe(42);
+                tfsCommentThread.Status.ShouldBe(TfsCommentThreadStatus.Pending);
+                tfsCommentThread.FilePath.ShouldNotBeNull();
+                tfsCommentThread.FilePath.FullPath.ShouldBe("src/myclass.cs");
+
+                tfsCommentThread.Comments.ShouldNotBeNull();
+                tfsCommentThread.Comments.ShouldNotBeEmpty();
+                tfsCommentThread.Comments.ShouldHaveSingleItem();
+                tfsCommentThread.Comments.First().ShouldNotBeNull();
+                tfsCommentThread.Comments.First().Content.ShouldBe("Hello");
+                tfsCommentThread.Comments.First().CommentType.ShouldBe(TfsCommentType.Text);
+                tfsCommentThread.Comments.First().IsDeleted.ShouldBeFalse();
+
+                tfsCommentThread.Properties.ShouldNotBeNull();
+                tfsCommentThread.Properties.ShouldBeEmpty();
+            }
+        }
+
+        public sealed class FilePath
+        {
+            [Fact]
+            public void Should_Return_Null_If_Not_Initialized()
+            {
+                // Given
+                var thread = new GitPullRequestCommentThread
+                {
+                    Id = 16,
+                    Status = CommentThreadStatus.Active
+                };
+
+                // When
+                var tfsThread = new TfsPullRequestCommentThread(thread);
+                var filePath = tfsThread.FilePath;
+
+                // Then
+                filePath.ShouldBeNull();
+            }
+
+            [Fact]
+            public void Should_Set_And_Trimmed_Properly()
+            {
+                // Given
+                var thread = new GitPullRequestCommentThread
+                {
+                    Id = 100,
+                    Status = CommentThreadStatus.Active
+                };
+
+                // When
+                var tfsThread = new TfsPullRequestCommentThread(thread);
+                tfsThread.FilePath = "/path/to/myclass.cs";
+
+                // Then
+                tfsThread.FilePath.ShouldNotBeNull();
+                tfsThread.FilePath.FullPath.ShouldBe("path/to/myclass.cs");
+            }
+        }
+
+        public sealed class Comments
+        {
+            [Fact]
+            public void Should_Throw_If_Not_Set()
+            {
+                // Given
+                var thread = new GitPullRequestCommentThread
+                {
+                    Id = 15,
+                    Status = CommentThreadStatus.Active
+                };
+
+                // When
+                var tfsThread = new TfsPullRequestCommentThread(thread);
+                var result = Record.Exception(() => tfsThread.Comments);
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Set_Properly()
+            {
+                // Given
+                var thread = new GitPullRequestCommentThread
+                {
+                    Id = 15,
+                    Status = CommentThreadStatus.Active
+                };
+
+                // When
+                var tfsThread = new TfsPullRequestCommentThread(thread)
+                {
+                    Comments = new List<TfsComment> { new TfsComment("hi", false, CommentType.Text) }
+                };
+
+                // Then
+                tfsThread.Comments.ShouldNotBeNull();
+                tfsThread.Comments.ShouldHaveSingleItem();
+                tfsThread.Comments.First().ShouldNotBeNull();
+                tfsThread.Comments.First().ShouldBeOfType<TfsComment>();
+                tfsThread.Comments.First().Content.ShouldBe("hi");
+                tfsThread.Comments.First().CommentType.ShouldBe(TfsCommentType.Text);
+                tfsThread.Comments.First().IsDeleted.ShouldBeFalse();
+            }
+        }
+
+        public sealed class Properties
+        {
+            [Fact]
+            public void Should_Return_Null_If_Not_Set()
+            {
+                // Given
+                var thread = new GitPullRequestCommentThread
+                {
+                    Id = 16,
+                    Status = CommentThreadStatus.Active
+                };
+
+                // When
+                var tfsThread = new TfsPullRequestCommentThread(thread);
+
+                // Then
+                tfsThread.Properties.ShouldBeNull();
+            }
+
+            [Fact]
+            public void Should_Set_Empty_Collection()
+            {
+                // Given
+                var thread = new GitPullRequestCommentThread
+                {
+                    Id = 16,
+                    Status = CommentThreadStatus.Active
+                };
+
+                // When
+                var tfsThread = new TfsPullRequestCommentThread(thread)
+                {
+                    Properties = new Dictionary<string, object>()
+                };
+
+                // Then
+                tfsThread.Properties.ShouldNotBeNull();
+                tfsThread.Properties.ShouldBeOfType<PropertiesCollection>();
+                tfsThread.Properties.ShouldBeEmpty();
+            }
+
+            [Fact]
+            public void Should_Set_Colletion_With_Single_Element()
+            {
+                // Given
+                var thread = new GitPullRequestCommentThread
+                {
+                    Id = 16,
+                    Status = CommentThreadStatus.Active,
+                    Properties = new PropertiesCollection()
+                };
+
+                // When
+                var tfsThread = new TfsPullRequestCommentThread(thread) { Properties = { ["fake"] = "value" } };
+
+                // Then
+                tfsThread.Properties.ShouldNotBeNull();
+                tfsThread.Properties.ShouldNotBeEmpty();
+                tfsThread.Properties.ShouldHaveSingleItem();
+
+                tfsThread.Properties["fake"].ShouldNotBeNull();
+                tfsThread.Properties["fake"].ShouldBe("value");
+            }
+        }
+
+        public sealed class GetValue
+        {
+            [Fact]
+            public void Should_Throw_If_Property_Name_Is_Null()
+            {
+                // Given
+                var tfsThread = new TfsPullRequestCommentThread();
+
+                // When
+                var result = Record.Exception(() => tfsThread.GetValue<string>(null));
+
+                // Then
+                result.IsArgumentNullException("propertyName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Property_Name_Is_Empty()
+            {
+                // Given
+                var tfsThread = new TfsPullRequestCommentThread();
+
+                // When
+                var result = Record.Exception(() => tfsThread.GetValue<object>(string.Empty));
+
+                // Then
+                result.IsArgumentOutOfRangeException("propertyName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Property_Collection_Is_Null()
+            {
+                // Given
+                var tfsThread = new TfsPullRequestCommentThread();
+
+                // When
+                var result = Record.Exception(() => tfsThread.GetValue<int>("key"));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Get_Valid_Properties()
+            {
+                // Given
+                var tfsThread = new TfsPullRequestCommentThread(
+                    new GitPullRequestCommentThread
+                    {
+                        Id = 42,
+                        Status = CommentThreadStatus.Active,
+                        Properties = new PropertiesCollection { { "one", "way" }, { "two", 2 } }
+                    });
+
+                // When
+                var prop1 = tfsThread.GetValue<string>("one");
+                var prop2 = tfsThread.GetValue<int>("two");
+                var prop3 = tfsThread.GetValue<object>("ghost");
+
+                // Then
+                prop1.ShouldNotBeNull();
+                prop1.ShouldBeOfType<string>();
+                prop1.ShouldNotBeEmpty();
+                prop1.ShouldBe("way");
+
+                prop2.ShouldNotBeNull();
+                prop2.ShouldBeOfType<int>();
+                prop2.ShouldBe(2);
+
+                prop3.ShouldBeNull();
+            }
+        }
+
+        public sealed class SetValue
+        {
+            [Fact]
+            public void Should_Throw_If_Property_Name_Is_Null()
+            {
+                // Given
+                var tfsThread = new TfsPullRequestCommentThread();
+
+                // When
+                var result = Record.Exception(() => tfsThread.SetValue(null, string.Empty));
+
+                // Then
+                result.IsArgumentNullException("propertyName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Property_Name_Is_Empty()
+            {
+                // Given
+                var tfsThread = new TfsPullRequestCommentThread();
+
+                // When
+                var result = Record.Exception(() => tfsThread.SetValue(string.Empty, new object()));
+
+                // Then
+                result.IsArgumentOutOfRangeException("propertyName");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Property_Collection_Is_Null()
+            {
+                // Given
+                var tfsThread = new TfsPullRequestCommentThread();
+
+                // When
+                var result = Record.Exception(() => tfsThread.SetValue("key", 1));
+
+                // Then
+                result.IsInvalidOperationException();
+            }
+
+            [Fact]
+            public void Should_Set_Valid_Properties()
+            {
+                // Given
+                var tfsThread = new TfsPullRequestCommentThread(
+                    new GitPullRequestCommentThread
+                    {
+                        Id = 42,
+                        Status = CommentThreadStatus.Active,
+                        Properties = new PropertiesCollection { { "one", 1 } }
+                    });
+
+                // When
+                tfsThread.SetValue("one", "string");
+                tfsThread.SetValue("two", 2);
+
+                // Then
+                tfsThread.Properties.ShouldNotBeNull();
+                tfsThread.Properties.ShouldNotBeEmpty();
+                tfsThread.Properties.ShouldContainKeyAndValue("one", "string");
+                tfsThread.Properties.ShouldContainKeyAndValue("two", 2);
+            }
+        }
+    }
+}

--- a/src/Cake.Tfs.Tests/PullRequest/TfsPullRequestTests.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/TfsPullRequestTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace Cake.Tfs.Tests.PullRequest
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Cake.Core.IO;
@@ -605,6 +606,54 @@
                 thread2.FilePath.ShouldBeNull();
                 thread2.Comments.ShouldNotBeNull();
                 thread2.Comments.ShouldBeEmpty();
+            }
+        }
+
+        public sealed class CreateCommentThread
+        {
+            [Fact]
+            public void Should_Throw_If_Input_Thread_Is_Null()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 100);
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                var result = Record.Exception(() => pullRequest.CreateCommentThread(null));
+
+                // Then
+                Assert.IsType<NullReferenceException>(result);
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Null_Is_Returned()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 100)
+                {
+                    GitClientFactory = new FakeNullForMethodsGitClientFactory()
+                };
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                pullRequest.CreateCommentThread(new TfsPullRequestCommentThread());
+
+                // Then
+                // ?? Nothing to validate here since the method returns void
+            }
+
+            [Fact]
+            public void Should_Create_Valid_Comment_Thread()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidAzureDevOpsUrl, 200);
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                pullRequest.CreateCommentThread(new TfsPullRequestCommentThread { Id = 300, Status = TfsCommentThreadStatus.Pending, FilePath = "/index.html" });
+
+                // Then
+                // ?? Nothing to validate here since the method returns void
             }
         }
     }

--- a/src/Cake.Tfs.Tests/PullRequest/TfsPullRequestTests.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/TfsPullRequestTests.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using Cake.Core.IO;
     using Cake.Tfs.PullRequest;
+    using Cake.Tfs.PullRequest.CommentThread;
     using Cake.Tfs.Tests.PullRequest.Fakes;
     using Microsoft.VisualStudio.Services.Common;
     using Shouldly;
@@ -538,6 +539,72 @@
 
                 // Then
                 // ?? Nothing to validate here since the method returns void
+            }
+        }
+
+        public sealed class GetCommentThreads
+        {
+            [Fact]
+            public void Should_Not_Fail_If_Empty_List_Is_Returned()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 33)
+                {
+                    GitClientFactory = new FakeNullForMethodsGitClientFactory()
+                };
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                var threads = pullRequest.GetCommentThreads();
+
+                // Then
+                threads.ShouldNotBeNull();
+                threads.ShouldBeEmpty();
+            }
+
+            [Fact]
+            public void Should_Return_Valid_Comment_Threads()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidAzureDevOpsUrl, 44);
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                var threads = pullRequest.GetCommentThreads();
+
+                // Then
+                threads.ShouldNotBeNull();
+                threads.ShouldNotBeEmpty();
+                threads.Count().ShouldBe(2);
+
+                TfsPullRequestCommentThread thread1 = threads.First();
+                thread1.Id.ShouldBe(11);
+                thread1.Status.ShouldBe(TfsCommentThreadStatus.Active);
+                thread1.FilePath.ShouldNotBeNull();
+                thread1.FilePath.FullPath.ShouldBe("some/path/to/file.cs");
+
+                thread1.Comments.ShouldNotBeNull();
+                thread1.Comments.ShouldNotBeEmpty();
+                thread1.Comments.Count().ShouldBe(2);
+
+                TfsComment comment11 = thread1.Comments.First();
+                comment11.ShouldNotBeNull();
+                comment11.Content.ShouldBe("Hello");
+                comment11.IsDeleted.ShouldBe(false);
+                comment11.CommentType.ShouldBe(TfsCommentType.CodeChange);
+
+                TfsComment comment12 = thread1.Comments.Last();
+                comment12.ShouldNotBeNull();
+                comment12.Content.ShouldBe("Goodbye");
+                comment12.IsDeleted.ShouldBe(true);
+                comment12.CommentType.ShouldBe(TfsCommentType.Text);
+
+                TfsPullRequestCommentThread thread2 = threads.Last();
+                thread2.Id.ShouldBe(22);
+                thread2.Status.ShouldBe(TfsCommentThreadStatus.Fixed);
+                thread2.FilePath.ShouldBeNull();
+                thread2.Comments.ShouldNotBeNull();
+                thread2.Comments.ShouldBeEmpty();
             }
         }
     }

--- a/src/Cake.Tfs.Tests/PullRequest/TfsPullRequestTests.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/TfsPullRequestTests.cs
@@ -491,5 +491,54 @@
                 filePath.FullPath.ShouldBe("src/project/myclass.cs");
             }
         }
+
+        public sealed class SetCommentThreadStatus
+        {
+            [Fact]
+            public void Should_Activate_Comment_Thread()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 12);
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                pullRequest.ActivateCommentThread(321);
+
+                // Then
+                // ?? Nothing to validate here since the method returns void
+            }
+
+            [Fact]
+            public void Should_Resolve_Comment_Thread()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidAzureDevOpsUrl, 21);
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                pullRequest.ResolveCommentThread(123);
+
+                // Then
+                // ?? Nothing to validate here since the method returns void
+            }
+
+            [Fact]
+            public void Should_Not_Throw_If_Null_Is_Returned()
+            {
+                // Given
+                var fixture = new PullRequestFixture(PullRequestFixture.ValidTfsUrl, 11)
+                {
+                    GitClientFactory = new FakeNullForMethodsGitClientFactory()
+                };
+                var pullRequest = new TfsPullRequest(fixture.Log, fixture.Settings, fixture.GitClientFactory);
+
+                // When
+                pullRequest.ActivateCommentThread(35);
+                pullRequest.ResolveCommentThread(53);
+
+                // Then
+                // ?? Nothing to validate here since the method returns void
+            }
+        }
     }
 }

--- a/src/Cake.Tfs/PullRequest/CommentThread/TfsComment.cs
+++ b/src/Cake.Tfs/PullRequest/CommentThread/TfsComment.cs
@@ -22,6 +22,19 @@
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="TfsComment"/> class.
+        /// </summary>
+        /// <param name="content">The content of the comment.</param>
+        /// <param name="isDeleted">Equals 'true' if a comment is deleted. Otherwise, 'false'.</param>
+        /// <param name="commentType">The type of the comment.</param>
+        public TfsComment(string content, bool isDeleted, CommentType commentType)
+        {
+            content.NotNullOrWhiteSpace(nameof(content));
+
+            this.comment = new Comment { Content = content, IsDeleted = isDeleted, CommentType = commentType };
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TfsComment"/> class with empty Git comment.
         /// </summary>
         public TfsComment()

--- a/src/Cake.Tfs/PullRequest/CommentThread/TfsComment.cs
+++ b/src/Cake.Tfs/PullRequest/CommentThread/TfsComment.cs
@@ -57,5 +57,14 @@
             get => this.comment.IsDeleted;
             set => this.comment.IsDeleted = value;
         }
+
+        /// <summary>
+        /// Gets or sets the comment type.
+        /// </summary>
+        public TfsCommentType CommentType
+        {
+            get => (TfsCommentType)this.comment.CommentType;
+            set => this.comment.CommentType = (CommentType)value;
+        }
     }
 }

--- a/src/Cake.Tfs/PullRequest/CommentThread/TfsComment.cs
+++ b/src/Cake.Tfs/PullRequest/CommentThread/TfsComment.cs
@@ -1,0 +1,61 @@
+﻿namespace Cake.Tfs.PullRequest.CommentThread
+{
+    using Microsoft.TeamFoundation.SourceControl.WebApi;
+
+    /// <summary>
+    /// Class representing a comment in the pull request comment thread.
+    /// </summary>
+    public class TfsComment
+    {
+        private readonly Comment comment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TfsComment"/> class.
+        /// </summary>
+        /// <param name="content">The content of the comment.</param>
+        /// <param name="isDeleted">Equals 'true' if a comment is deleted. Otherwise, 'false'.</param>
+        public TfsComment(string content, bool isDeleted)
+        {
+            content.NotNullOrWhiteSpace(nameof(content));
+
+            this.comment = new Comment { Content = content, IsDeleted = isDeleted };
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TfsComment"/> class with empty Git comment.
+        /// </summary>
+        public TfsComment()
+            : this(new Comment())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TfsComment"/> class with real Git comment.
+        /// </summary>
+        /// <param name="comment">The original TFS or Azure DevOps pull request comment.</param>
+        internal TfsComment(Comment comment)
+        {
+            comment.NotNull(nameof(comment));
+
+            this.comment = comment;
+        }
+
+        /// <summary>
+        /// Gets or sets the content of the pull request comment.
+        /// </summary>
+        public string Content
+        {
+            get => this.comment.Content;
+            set => this.comment.Content = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the comment is deleted.
+        /// </summary>
+        public bool IsDeleted
+        {
+            get => this.comment.IsDeleted;
+            set => this.comment.IsDeleted = value;
+        }
+    }
+}

--- a/src/Cake.Tfs/PullRequest/CommentThread/TfsCommentThreadStatus.cs
+++ b/src/Cake.Tfs/PullRequest/CommentThread/TfsCommentThreadStatus.cs
@@ -1,0 +1,45 @@
+﻿namespace Cake.Tfs.PullRequest.CommentThread
+{
+    using Microsoft.TeamFoundation.SourceControl.WebApi;
+
+    /// <summary>
+    /// The wrapper around the native TFS API comment thread status
+    /// </summary>
+    public enum TfsCommentThreadStatus
+    {
+        /// <summary>
+        /// The comment thread is active.
+        /// </summary>
+        Active = CommentThreadStatus.Active,
+
+        /// <summary>
+        /// The comment thread status is by design.
+        /// </summary>
+        ByDesign = CommentThreadStatus.ByDesign,
+
+        /// <summary>
+        /// The comment thread is closed.
+        /// </summary>
+        Closed = CommentThreadStatus.Closed,
+
+        /// <summary>
+        /// The comment thread is fixed.
+        /// </summary>
+        Fixed = CommentThreadStatus.Fixed,
+
+        /// <summary>
+        /// The comment thread is pending.
+        /// </summary>
+        Pending = CommentThreadStatus.Pending,
+
+        /// <summary>
+        /// Unknown comment thread status.
+        /// </summary>
+        Unknown = CommentThreadStatus.Unknown,
+
+        /// <summary>
+        /// The comment thread won't be fixed.
+        /// </summary>
+        WontFix = CommentThreadStatus.WontFix
+    }
+}

--- a/src/Cake.Tfs/PullRequest/CommentThread/TfsCommentType.cs
+++ b/src/Cake.Tfs/PullRequest/CommentThread/TfsCommentType.cs
@@ -1,0 +1,30 @@
+﻿namespace Cake.Tfs.PullRequest.CommentThread
+{
+    using Microsoft.TeamFoundation.SourceControl.WebApi;
+
+    /// <summary>
+    /// The wrapper around the native TFS API comment type
+    /// </summary>
+    public enum TfsCommentType
+    {
+        /// <summary>
+        /// Unknown comment type.
+        /// </summary>
+        Unknown = CommentType.Unknown,
+
+        /// <summary>
+        /// The comment is text.
+        /// </summary>
+        Text = CommentType.Text,
+
+        /// <summary>
+        /// The comment is a code change.
+        /// </summary>
+        CodeChange = CommentType.CodeChange,
+
+        /// <summary>
+        /// System comment.
+        /// </summary>
+        System = CommentType.System
+    }
+}

--- a/src/Cake.Tfs/PullRequest/CommentThread/TfsPullRequestCommentThread.cs
+++ b/src/Cake.Tfs/PullRequest/CommentThread/TfsPullRequestCommentThread.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Cake.Core.IO;
     using Microsoft.TeamFoundation.SourceControl.WebApi;
     using Microsoft.VisualStudio.Services.WebApi;
 
@@ -55,11 +56,11 @@
         /// Gets or sets the path of the modified file the pull request comment thread belongs to.
         /// Returns 'null' for the comment threads not related to any particular file.
         /// </summary>
-        public string FilePath
+        public FilePath FilePath
         {
             get
             {
-                string filePath = null;
+                FilePath filePath = null;
                 if (this.thread.ThreadContext?.FilePath != null)
                 {
                     filePath = this.thread.ThreadContext.FilePath.TrimStart('/');
@@ -75,7 +76,7 @@
                     this.thread.ThreadContext = new CommentThreadContext();
                 }
 
-                this.thread.ThreadContext.FilePath = value;
+                this.thread.ThreadContext.FilePath = value.FullPath;
             }
         }
 

--- a/src/Cake.Tfs/PullRequest/CommentThread/TfsPullRequestCommentThread.cs
+++ b/src/Cake.Tfs/PullRequest/CommentThread/TfsPullRequestCommentThread.cs
@@ -1,0 +1,155 @@
+﻿namespace Cake.Tfs.PullRequest.CommentThread
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.TeamFoundation.SourceControl.WebApi;
+    using Microsoft.VisualStudio.Services.WebApi;
+
+    /// <summary>
+    /// Class for dealing with comments in pull requests.
+    /// </summary>
+    public class TfsPullRequestCommentThread
+    {
+        private readonly GitPullRequestCommentThread thread;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TfsPullRequestCommentThread"/> class.
+        /// </summary>
+        public TfsPullRequestCommentThread()
+            : this(new GitPullRequestCommentThread())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TfsPullRequestCommentThread"/> class.
+        /// TODO: This ctor must become internal.
+        /// </summary>
+        /// <param name="thread">The original comment thread in TFS or Azue DevOps pull request.</param>
+        public TfsPullRequestCommentThread(GitPullRequestCommentThread thread)
+        {
+            thread.NotNull(nameof(thread));
+
+            this.thread = thread;
+        }
+
+        /// <summary>
+        /// Gets or sets the Id of the pull request comment thread.
+        /// </summary>
+        public int Id
+        {
+            get => this.thread.Id;
+            set => this.thread.Id = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the status of the pull request comment thread.
+        /// </summary>
+        public TfsCommentThreadStatus Status
+        {
+            get => (TfsCommentThreadStatus)this.thread.Status;
+            set => this.thread.Status = (CommentThreadStatus)value;
+        }
+
+        /// <summary>
+        /// Gets or sets the path of the modified file the pull request comment thread belongs to.
+        /// Returns 'null' for the comment threads not related to any particular file.
+        /// </summary>
+        public string FilePath
+        {
+            get
+            {
+                string filePath = null;
+                if (this.thread.ThreadContext?.FilePath != null)
+                {
+                    filePath = this.thread.ThreadContext.FilePath.TrimStart('/');
+                }
+
+                return filePath;
+            }
+
+            set
+            {
+                if (this.thread.ThreadContext == null)
+                {
+                    this.thread.ThreadContext = new CommentThreadContext();
+                }
+
+                this.thread.ThreadContext.FilePath = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the collection of comments in the pull request comment thread.
+        /// </summary>
+        public IEnumerable<TfsComment> Comments
+        {
+            get
+            {
+                if (this.thread.Comments == null)
+                {
+                    throw new InvalidOperationException("Comments list is not created.");
+                }
+
+                return this.thread.Comments.Select(x => new TfsComment(x));
+            }
+
+            set
+            {
+                this.thread.Comments = value?.Select(c => new Comment { Content = c.Content, IsDeleted = c.IsDeleted }).ToList();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the collection of properties of the pull request comment thread.
+        /// </summary>
+        public IDictionary<string, object> Properties
+        {
+            get => this.thread.Properties;
+            set => this.thread.Properties = value != null ? new PropertiesCollection(value) : null;
+        }
+
+        /// <summary>
+        /// Gets the value of the thread property.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <returns>Value of the property.</returns>
+        public T GetValue<T>(string propertyName)
+        {
+            propertyName.NotNullOrWhiteSpace(nameof(propertyName));
+
+            if (this.thread.Properties == null)
+            {
+                throw new InvalidOperationException("Properties collection is not created.");
+            }
+
+            return this.thread.Properties.GetValue(propertyName, default(T));
+        }
+
+        /// <summary>
+        /// Sets a value in the thread properties.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <param name="value">Value to set.</param>
+        public void SetValue<T>(string propertyName, T value)
+        {
+            propertyName.NotNullOrWhiteSpace(nameof(propertyName));
+
+            if (this.thread.Properties == null)
+            {
+                throw new InvalidOperationException("Properties collection is not created.");
+            }
+
+            if (this.thread.Properties.ContainsKey(propertyName))
+            {
+                this.thread.Properties[propertyName] = value;
+            }
+            else
+            {
+                this.thread.Properties.Add(propertyName, value);
+            }
+        }
+    }
+}

--- a/src/Cake.Tfs/PullRequest/CommentThread/TfsPullRequestCommentThread.cs
+++ b/src/Cake.Tfs/PullRequest/CommentThread/TfsPullRequestCommentThread.cs
@@ -96,7 +96,7 @@
 
             set
             {
-                this.thread.Comments = value?.Select(c => new Comment { Content = c.Content, IsDeleted = c.IsDeleted }).ToList();
+                this.thread.Comments = value?.Select(c => new Comment { Content = c.Content, IsDeleted = c.IsDeleted, CommentType = (CommentType)c.CommentType }).ToList();
             }
         }
 

--- a/src/Cake.Tfs/PullRequest/CommentThread/TfsPullRequestCommentThread.cs
+++ b/src/Cake.Tfs/PullRequest/CommentThread/TfsPullRequestCommentThread.cs
@@ -24,10 +24,9 @@
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TfsPullRequestCommentThread"/> class.
-        /// TODO: This ctor must become internal.
         /// </summary>
         /// <param name="thread">The original comment thread in TFS or Azue DevOps pull request.</param>
-        public TfsPullRequestCommentThread(GitPullRequestCommentThread thread)
+        internal TfsPullRequestCommentThread(GitPullRequestCommentThread thread)
         {
             thread.NotNull(nameof(thread));
 
@@ -109,6 +108,11 @@
             get => this.thread.Properties;
             set => this.thread.Properties = value != null ? new PropertiesCollection(value) : null;
         }
+
+        /// <summary>
+        /// Gets the inner Git comment thread object. Intended for the internal use only.
+        /// </summary>
+        internal GitPullRequestCommentThread InnerThread => this.thread;
 
         /// <summary>
         /// Gets the value of the thread property.

--- a/src/Cake.Tfs/PullRequest/TfsPullRequest.cs
+++ b/src/Cake.Tfs/PullRequest/TfsPullRequest.cs
@@ -488,6 +488,28 @@
         }
 
         /// <summary>
+        /// Creates a new comment thread in the pull request.
+        /// </summary>
+        /// <param name="thread">The instance of the thread.</param>
+        public void CreateCommentThread(TfsPullRequestCommentThread thread)
+        {
+            if (!this.ValidatePullRequest())
+            {
+                return;
+            }
+
+            using (var gitClient = this.gitClientFactory.CreateGitClient(this.CollectionUrl, this.settings.Credentials))
+            {
+                gitClient.CreateThreadAsync(
+                    thread.InnerThread,
+                    this.RepositoryId,
+                    this.PullRequestId,
+                    null,
+                    CancellationToken.None).Wait();
+            }
+        }
+
+        /// <summary>
         /// Sets the pull request comment thread status.
         /// </summary>
         /// <param name="threadId">The Id of the comment thread.</param>


### PR DESCRIPTION
This is an attempt to continue with [this one](https://github.com/cake-contrib/Cake.Issues.PullRequests.Tfs/issues/22) and move the functionality related to the comment threads. As long as one of the methods was returning `GitPullRequestCommentThread`, I've added some wrapper classes to hide TFS API in `Cake.Tfs`. 

If I understood you correctly, this is one of the alternatives you described. On one hand, it isolates the TFS API, but on the other hand, several classes were introduced for that purpose only... Please, let me know what you think. 

The code lacks some tests and needs polishing. I'll put it into order once we agree on the concept.
I'll also create a separate PR to `Cake.Issues.PullRequests.Tfs` to track how the calling code changes when these enhancements are consumed.

Fixes #62 
Fixes #63
Fixes #64