### PR TITLE
 Add methods to work with pull request iterations and iteration changes

### DIFF
--- a/src/Cake.Tfs.Tests/ExceptionAssertExtensions.cs
+++ b/src/Cake.Tfs.Tests/ExceptionAssertExtensions.cs
@@ -68,5 +68,14 @@
         {
             Assert.IsType<TfsPullRequestNotFoundException>(exception);
         }
+
+        /// <summary>
+        /// Checks if an exception is of type <see cref="TfsException"/>
+        /// </summary>
+        /// <param name="exception">Exceptino to check.</param>
+        public static void IsTfsException(this Exception exception)
+        {
+            Assert.IsType<TfsException>(exception);
+        }
     }
 }

--- a/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeAllSetGitClientFactory.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeAllSetGitClientFactory.cs
@@ -192,6 +192,53 @@
              .ReturnsAsync((GitPullRequestCommentThread prct, Guid g, int i, object o, CancellationToken c)
                     => prct);
 
+            m.Setup(arg => arg.GetPullRequestIterationsAsync(
+                It.IsAny<Guid>(),
+                It.Is<int>(i => i != 13),
+                null,
+                null,
+                CancellationToken.None))
+             .ReturnsAsync((Guid repoId, int prId, bool? b, object o, CancellationToken c)
+                    => new List<GitPullRequestIteration>
+                    {
+                        new GitPullRequestIteration { Id = 42, CreatedDate = DateTime.Today.AddDays(-3) },
+                        new GitPullRequestIteration { Id = 16, CreatedDate = DateTime.Today.AddDays(-1) }
+                    });
+
+            m.Setup(arg => arg.GetPullRequestIterationsAsync(
+                    It.IsAny<Guid>(),
+                    It.Is<int>(i => i == 13), // Just to emulate the unlucky case
+                    null,
+                    null,
+                    CancellationToken.None))
+                .ReturnsAsync((Guid repoId, int prId, bool? b, object o, CancellationToken c)
+                    => new List<GitPullRequestIteration>
+                    {
+                        new GitPullRequestIteration { Id = null }
+                    });
+
+            // Setup GitPullRequestIterationChanges collection
+            var changes = new GitPullRequestIterationChanges
+            {
+                ChangeEntries = new List<GitPullRequestChange>
+                {
+                    new GitPullRequestChange { ChangeId = 100, ChangeTrackingId = 1, Item = new GitItem { Path = "/src/my/class1.cs" } },
+                    new GitPullRequestChange { ChangeId = 200, ChangeTrackingId = 2, Item = new GitItem { Path = string.Empty } }
+                }
+            };
+
+            m.Setup(arg => arg.GetPullRequestIterationChangesAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<int>(),
+                It.IsAny<int>(),
+                null,
+                null,
+                null,
+                null,
+                CancellationToken.None))
+             .ReturnsAsync((Guid repoId, int prId, int iterId, int? t, int? s, int? ct, object o, CancellationToken c)
+                    => changes);
+
             return m;
         }
     }

--- a/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeNullForMethodsGitClientFactory.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/Fakes/FakeNullForMethodsGitClientFactory.cs
@@ -27,7 +27,13 @@
              .ReturnsAsync(() => new List<GitPullRequestCommentThread>());
 
             m.Setup(arg => arg.CreateThreadAsync(It.IsAny<GitPullRequestCommentThread>(), It.IsAny<Guid>(), It.IsAny<int>(), null, CancellationToken.None))
-                .ReturnsAsync(() => null);
+             .ReturnsAsync(() => null);
+
+            m.Setup(arg => arg.GetPullRequestIterationsAsync(It.IsAny<Guid>(), It.IsAny<int>(), null, null, CancellationToken.None))
+             .ReturnsAsync(() => null);
+
+            m.Setup(arg => arg.GetPullRequestIterationChangesAsync(It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), null, null, null, null, CancellationToken.None))
+             .ReturnsAsync(() => null);
 
             return m;
         }

--- a/src/Cake.Tfs/PullRequest/TfsPullRequest.cs
+++ b/src/Cake.Tfs/PullRequest/TfsPullRequest.cs
@@ -8,6 +8,7 @@
     using Cake.Core.IO;
     using Cake.Tfs;
     using Cake.Tfs.PullRequest.CommentThread;
+    using Microsoft.TeamFoundation.Common;
     using Microsoft.TeamFoundation.SourceControl.WebApi;
     using TfsUrlParser;
 
@@ -512,7 +513,8 @@
         /// <summary>
         /// Gets the Id of the latest pull request iteration.
         /// </summary>
-        /// <returns>The Id of the pull request iteration.</returns>
+        /// <returns>The Id of the pull request iteration. Returns -1 in case the pull request is not valid.</returns>
+        /// <exception cref="TfsException">If it is not possible to obtain a collection of <see cref="GitPullRequestIteration"/>.</exception>
         public int GetLatestIterationId()
         {
             if (!this.ValidatePullRequest())
@@ -543,7 +545,7 @@
         /// Gets all the pull request changes of the given iteration.
         /// </summary>
         /// <param name="iterationId">The id of the iteration.</param>
-        /// <returns>The colletion of the iteration changes of the given id.</returns>
+        /// <returns>The colletion of the iteration changes of the given id. Returns <code>null</code> if pull request is not valid.</returns>
         public IEnumerable<TfsPullRequestIterationChange> GetIterationChanges(int iterationId)
         {
             if (!this.ValidatePullRequest())
@@ -569,7 +571,7 @@
                     {
                         ChangeId = c.ChangeId,
                         ChangeTrackingId = c.ChangeTrackingId,
-                        ItemPath = c.Item.Path
+                        ItemPath = c.Item.Path.IsNullOrEmpty() ? null : new FilePath(c.Item.Path)
                     });
 
                 return tfsChanges;

--- a/src/Cake.Tfs/PullRequest/TfsPullRequestIterationChange.cs
+++ b/src/Cake.Tfs/PullRequest/TfsPullRequestIterationChange.cs
@@ -1,0 +1,23 @@
+﻿namespace Cake.Tfs.PullRequest
+{
+    /// <summary>
+    /// Class representing an iteration change of the pull request.
+    /// </summary>
+    public class TfsPullRequestIterationChange
+    {
+        /// <summary>
+        /// Gets or sets the file path the iteration change is associated with.
+        /// </summary>
+        public string ItemPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the id of the iteration change.
+        /// </summary>
+        public int ChangeId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tracking id of the iteration change.
+        /// </summary>
+        public int ChangeTrackingId { get; set; }
+    }
+}

--- a/src/Cake.Tfs/PullRequest/TfsPullRequestIterationChange.cs
+++ b/src/Cake.Tfs/PullRequest/TfsPullRequestIterationChange.cs
@@ -1,5 +1,7 @@
 ﻿namespace Cake.Tfs.PullRequest
 {
+    using Cake.Core.IO;
+
     /// <summary>
     /// Class representing an iteration change of the pull request.
     /// </summary>
@@ -8,7 +10,7 @@
         /// <summary>
         /// Gets or sets the file path the iteration change is associated with.
         /// </summary>
-        public string ItemPath { get; set; }
+        public FilePath ItemPath { get; set; }
 
         /// <summary>
         /// Gets or sets the id of the iteration change.


### PR DESCRIPTION
@pascalberger Hopefully, the last part to support [this one](https://github.com/cake-contrib/Cake.Issues.PullRequests.Tfs/issues/22). The methods to work with pull request iterations and iteration changes were added: `GetLatestIterationId` and `GetIterationChanges`. This enables the removal of the last direct calls to `GitClient` in Cake.Issues.PullRequests.Tfs.

One question though: can we make the `ValidatePullRequest` method of the `TfsPullRequest` public? If so, we won't need a special method in `ITfsPullRequestSystem` interface.