### PR TITLE
(GH-84) Return default value in case property collection is not initialized

### DIFF
--- a/src/Cake.Tfs.Tests/PullRequest/CommentThread/TfsPullRequestCommentThreadTests.cs
+++ b/src/Cake.Tfs.Tests/PullRequest/CommentThread/TfsPullRequestCommentThreadTests.cs
@@ -259,16 +259,67 @@
             }
 
             [Fact]
-            public void Should_Throw_If_Property_Collection_Is_Null()
+            public void Should_Return_Default_Value_If_Property_Collection_Is_Null_For_String_Value()
             {
                 // Given
                 var tfsThread = new TfsPullRequestCommentThread();
 
                 // When
-                var result = Record.Exception(() => tfsThread.GetValue<int>("key"));
+                var result = tfsThread.GetValue<string>("key");
 
                 // Then
-                result.IsInvalidOperationException();
+                result.ShouldBe(default(string));
+            }
+
+            [Fact]
+            public void Should_Return_Default_Value_If_Property_Collection_Is_Null_For_Integer_Value()
+            {
+                // Given
+                var tfsThread = new TfsPullRequestCommentThread();
+
+                // When
+                var result = tfsThread.GetValue<int>("key");
+
+                // Then
+                result.ShouldBe(default(int));
+            }
+
+            [Fact]
+            public void Should_Return_Default_Value_If_Property_Does_Not_Exist_For_String_Value()
+            {
+                // Given
+                var tfsThread = new TfsPullRequestCommentThread(
+                    new GitPullRequestCommentThread
+                    {
+                        Id = 42,
+                        Status = CommentThreadStatus.Active,
+                        Properties = new PropertiesCollection()
+                    });
+
+                // When
+                var result = tfsThread.GetValue<string>("key");
+
+                // Then
+                result.ShouldBe(default(string));
+            }
+
+            [Fact]
+            public void Should_Return_Default_Value_If_Property_Does_Not_Exist_For_Int_Value()
+            {
+                // Given
+                var tfsThread = new TfsPullRequestCommentThread(
+                    new GitPullRequestCommentThread
+                    {
+                        Id = 42,
+                        Status = CommentThreadStatus.Active,
+                        Properties = new PropertiesCollection()
+                    });
+
+                // When
+                var result = tfsThread.GetValue<int>("key");
+
+                // Then
+                result.ShouldBe(default(int));
             }
 
             [Fact]

--- a/src/Cake.Tfs/PullRequest/CommentThread/TfsPullRequestCommentThread.cs
+++ b/src/Cake.Tfs/PullRequest/CommentThread/TfsPullRequestCommentThread.cs
@@ -119,14 +119,14 @@
         /// </summary>
         /// <typeparam name="T">Type of the value.</typeparam>
         /// <param name="propertyName">Name of the property.</param>
-        /// <returns>Value of the property.</returns>
+        /// <returns>Value of the property or default value for <typeparamref name="T"/> if property does not exist.</returns>
         public T GetValue<T>(string propertyName)
         {
             propertyName.NotNullOrWhiteSpace(nameof(propertyName));
 
             if (this.thread.Properties == null)
             {
-                throw new InvalidOperationException("Properties collection is not created.");
+                return default(T);
             }
 
             return this.thread.Properties.GetValue(propertyName, default(T));
@@ -138,6 +138,7 @@
         /// <typeparam name="T">Type of the value.</typeparam>
         /// <param name="propertyName">Name of the property.</param>
         /// <param name="value">Value to set.</param>
+        /// <exception cref="InvalidOperationException">If properties collection is not created.</exception>
         public void SetValue<T>(string propertyName, T value)
         {
             propertyName.NotNullOrWhiteSpace(nameof(propertyName));


### PR DESCRIPTION
Returns default value while reading a property from a comment thread in case property collection is not initialized. Like this the behavior is consistent if the property collection is not initialized or if the property does not exist.

Fixes #84 