### PR TITLE
Add Title and Description properties to AzureDevOpsPullRequest

### DIFF
--- a/src/Cake.AzureDevOps.Tests/Fakes/FakeAllSetGitClientFactory.cs
+++ b/src/Cake.AzureDevOps.Tests/Fakes/FakeAllSetGitClientFactory.cs
@@ -27,6 +27,8 @@
                     SourceRefName = "foo",
                     TargetRefName = "master",
                     CodeReviewId = 123,
+                    Title = "Add feature X",
+                    Description = "This pull request adds feature X.",
                     LastMergeSourceCommit = new GitCommitRef { CommitId = "4a92b977" },
                     LastMergeTargetCommit = new GitCommitRef { CommitId = "78a3c113" },
                 });
@@ -55,6 +57,8 @@
                                 SourceRefName = sc.SourceRefName,
                                 TargetRefName = "master",
                                 CodeReviewId = 123,
+                                Title = "Add feature X",
+                                Description = "This pull request adds feature X.",
                                 LastMergeSourceCommit = new GitCommitRef { CommitId = "4a92b977" },
                                 LastMergeTargetCommit = new GitCommitRef { CommitId = "78a3c113" },
                             },

--- a/src/Cake.AzureDevOps.Tests/Repos/PullRequest/AzureDevOpsPullRequestTests.cs
+++ b/src/Cake.AzureDevOps.Tests/Repos/PullRequest/AzureDevOpsPullRequestTests.cs
@@ -131,6 +131,8 @@
                 pullRequest.ProjectName.ShouldBe("MyTeamProject");
                 pullRequest.SourceRefName.ShouldBe("foo");
                 pullRequest.TargetRefName.ShouldBe("master");
+                pullRequest.Title.ShouldBe("Add feature X");
+                pullRequest.Description.ShouldBe("This pull request adds feature X.");
                 pullRequest.LastSourceCommitId.ShouldBe("4a92b977");
                 pullRequest.LastTargetCommitId.ShouldBe("78a3c113");
             }
@@ -155,6 +157,8 @@
                 pullRequest.ProjectName.ShouldBe("MyProject");
                 pullRequest.SourceRefName.ShouldBe("foo");
                 pullRequest.TargetRefName.ShouldBe("master");
+                pullRequest.Title.ShouldBe("Add feature X");
+                pullRequest.Description.ShouldBe("This pull request adds feature X.");
                 pullRequest.LastSourceCommitId.ShouldBe("4a92b977");
                 pullRequest.LastTargetCommitId.ShouldBe("78a3c113");
             }
@@ -179,6 +183,8 @@
                 pullRequest.ProjectName.ShouldBe("MyTeamProject");
                 pullRequest.SourceRefName.ShouldBe("feature");
                 pullRequest.TargetRefName.ShouldBe("master");
+                pullRequest.Title.ShouldBe("Add feature X");
+                pullRequest.Description.ShouldBe("This pull request adds feature X.");
                 pullRequest.LastSourceCommitId.ShouldBe("4a92b977");
                 pullRequest.LastTargetCommitId.ShouldBe("78a3c113");
             }
@@ -203,6 +209,8 @@
                 pullRequest.ProjectName.ShouldBe("MyProject");
                 pullRequest.SourceRefName.ShouldBe("feature");
                 pullRequest.TargetRefName.ShouldBe("master");
+                pullRequest.Title.ShouldBe("Add feature X");
+                pullRequest.Description.ShouldBe("This pull request adds feature X.");
                 pullRequest.LastSourceCommitId.ShouldBe("4a92b977");
                 pullRequest.LastTargetCommitId.ShouldBe("78a3c113");
             }
@@ -232,6 +240,8 @@
                 pullRequest.CodeReviewId.ShouldBe(0);
                 pullRequest.SourceRefName.ShouldBeEmpty();
                 pullRequest.TargetRefName.ShouldBeEmpty();
+                pullRequest.Title.ShouldBeEmpty();
+                pullRequest.Description.ShouldBeEmpty();
                 pullRequest.LastSourceCommitId.ShouldBeEmpty();
                 pullRequest.LastTargetCommitId.ShouldBeEmpty();
             }
@@ -261,6 +271,8 @@
                 pullRequest.CodeReviewId.ShouldBe(0);
                 pullRequest.SourceRefName.ShouldBeEmpty();
                 pullRequest.TargetRefName.ShouldBeEmpty();
+                pullRequest.Title.ShouldBeEmpty();
+                pullRequest.Description.ShouldBeEmpty();
                 pullRequest.LastSourceCommitId.ShouldBeEmpty();
                 pullRequest.LastTargetCommitId.ShouldBeEmpty();
             }
@@ -290,6 +302,8 @@
                 pullRequest.CodeReviewId.ShouldBe(0);
                 pullRequest.SourceRefName.ShouldBeEmpty();
                 pullRequest.TargetRefName.ShouldBeEmpty();
+                pullRequest.Title.ShouldBeEmpty();
+                pullRequest.Description.ShouldBeEmpty();
                 pullRequest.LastSourceCommitId.ShouldBeEmpty();
                 pullRequest.LastTargetCommitId.ShouldBeEmpty();
             }
@@ -319,6 +333,8 @@
                 pullRequest.CodeReviewId.ShouldBe(0);
                 pullRequest.SourceRefName.ShouldBeEmpty();
                 pullRequest.TargetRefName.ShouldBeEmpty();
+                pullRequest.Title.ShouldBeEmpty();
+                pullRequest.Description.ShouldBeEmpty();
                 pullRequest.LastSourceCommitId.ShouldBeEmpty();
                 pullRequest.LastTargetCommitId.ShouldBeEmpty();
             }

--- a/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequest.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequest.cs
@@ -183,6 +183,24 @@
         public int PullRequestId => this.ValidatePullRequest() ? this.pullRequest.PullRequestId : 0;
 
         /// <summary>
+        /// Gets the title of the pull request.
+        /// Returns <see cref="string.Empty"/> if no pull request could be found and
+        /// <see cref="AzureDevOpsPullRequestSettings.ThrowExceptionIfPullRequestCouldNotBeFound"/> is set to <c>false</c>.
+        /// </summary>
+        /// <exception cref="AzureDevOpsPullRequestNotFoundException">If pull request could not be found and
+        /// <see cref="AzureDevOpsPullRequestSettings.ThrowExceptionIfPullRequestCouldNotBeFound"/> is set to <c>true</c>.</exception>
+        public string Title => this.ValidatePullRequest() ? this.pullRequest.Title : string.Empty;
+
+        /// <summary>
+        /// Gets the description of the pull request.
+        /// Returns <see cref="string.Empty"/> if no pull request could be found and
+        /// <see cref="AzureDevOpsPullRequestSettings.ThrowExceptionIfPullRequestCouldNotBeFound"/> is set to <c>false</c>.
+        /// </summary>
+        /// <exception cref="AzureDevOpsPullRequestNotFoundException">If pull request could not be found and
+        /// <see cref="AzureDevOpsPullRequestSettings.ThrowExceptionIfPullRequestCouldNotBeFound"/> is set to <c>true</c>.</exception>
+        public string Description => this.ValidatePullRequest() ? this.pullRequest.Description : string.Empty;
+
+        /// <summary>
         /// Gets if the pull request is in draft mode.
         /// Returns <see cref="AzureDevOpsPullRequestState.NotSet"/> if no pull request could be found and
         /// <see cref="AzureDevOpsPullRequestSettings.ThrowExceptionIfPullRequestCouldNotBeFound"/> is set to <c>false</c>.

--- a/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequest.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequest.cs
@@ -189,7 +189,7 @@
         /// </summary>
         /// <exception cref="AzureDevOpsPullRequestNotFoundException">If pull request could not be found and
         /// <see cref="AzureDevOpsPullRequestSettings.ThrowExceptionIfPullRequestCouldNotBeFound"/> is set to <c>true</c>.</exception>
-public string Title => this.ValidatePullRequest() ? (this.pullRequest.Title ?? string.Empty) : string.Empty;
+        public string Title => this.ValidatePullRequest() ? (this.pullRequest.Title ?? string.Empty) : string.Empty;
 
         /// <summary>
         /// Gets the description of the pull request.
@@ -198,7 +198,7 @@ public string Title => this.ValidatePullRequest() ? (this.pullRequest.Title ?? s
         /// </summary>
         /// <exception cref="AzureDevOpsPullRequestNotFoundException">If pull request could not be found and
         /// <see cref="AzureDevOpsPullRequestSettings.ThrowExceptionIfPullRequestCouldNotBeFound"/> is set to <c>true</c>.</exception>
-public string Description => this.ValidatePullRequest() ? (this.pullRequest.Description ?? string.Empty) : string.Empty;
+        public string Description => this.ValidatePullRequest() ? (this.pullRequest.Description ?? string.Empty) : string.Empty;
 
         /// <summary>
         /// Gets if the pull request is in draft mode.

--- a/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequest.cs
+++ b/src/Cake.AzureDevOps/Repos/PullRequest/AzureDevOpsPullRequest.cs
@@ -189,7 +189,7 @@
         /// </summary>
         /// <exception cref="AzureDevOpsPullRequestNotFoundException">If pull request could not be found and
         /// <see cref="AzureDevOpsPullRequestSettings.ThrowExceptionIfPullRequestCouldNotBeFound"/> is set to <c>true</c>.</exception>
-        public string Title => this.ValidatePullRequest() ? this.pullRequest.Title : string.Empty;
+public string Title => this.ValidatePullRequest() ? (this.pullRequest.Title ?? string.Empty) : string.Empty;
 
         /// <summary>
         /// Gets the description of the pull request.
@@ -198,7 +198,7 @@
         /// </summary>
         /// <exception cref="AzureDevOpsPullRequestNotFoundException">If pull request could not be found and
         /// <see cref="AzureDevOpsPullRequestSettings.ThrowExceptionIfPullRequestCouldNotBeFound"/> is set to <c>true</c>.</exception>
-        public string Description => this.ValidatePullRequest() ? this.pullRequest.Description : string.Empty;
+public string Description => this.ValidatePullRequest() ? (this.pullRequest.Description ?? string.Empty) : string.Empty;
 
         /// <summary>
         /// Gets if the pull request is in draft mode.


### PR DESCRIPTION
Surfaces the pull request `Title` and `Description` as read-only
properties on `AzureDevOpsPullRequest`, so they can be read after
fetching a PR by ID or source branch.